### PR TITLE
feat: standardize on MSYS2 UCRT64 and remove WSL2 references

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,7 @@
   "C_Cpp.clang_format_style": "file",
   "C_Cpp.clang_format_path": "C:\\msys64\\ucrt64\\bin\\clang-format.exe",
   "cSpell.words": [
+    "ctest",
     "GLFW",
     "GLSL",
     "HLSL",

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # steeplejack
 
-Experimental C++/Vulkan playground for Windows. Everything builds via MSYS2 UCRT64; WSL2 is optional for tooling/tests (no Vulkan runtime there).
+Experimental C++/Vulkan playground for Windows. Everything builds via MSYS2 UCRT64.
 
 ## Prerequisites
 
 - Follow [docs/MSYS2.md](docs/MSYS2.md) to set up MSYS2 UCRT64, compilers, and the required vcpkg defaults.
 - Follow [docs/vcpkg.md](docs/vcpkg.md) to bootstrap the package manager.
-- (Optional) Read [docs/environments.md](docs/environments.md) if you want the WSL2 helper environment for tooling/tests.
 
 ## Build / Run
 
-Use the project task runner `sj` at the repo root. It detects the host (MSYS2 UCRT vs WSL2), selects the right toolchain, keeps separate Debug/Release build folders, chains through vcpkg when `VCPKG_ROOT` is set, and preserves dependency caches on clean.
+Use the project task runner `sj` at the repo root. It targets MSYS2 UCRT64, keeps separate Debug/Release build folders, chains through vcpkg when `VCPKG_ROOT` is set, and preserves dependency caches on clean.
 
 ```bash
 ./sj build [debug|release]   # configure + build (defaults to debug)

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,3 +1,3 @@
 # CMake Helpers
 
-Custom modules and toolchain files (e.g., MSYS2, WSL2) live here.
+Custom modules and toolchain files (e.g., MSYS2) live here.

--- a/docs/MSYS2.md
+++ b/docs/MSYS2.md
@@ -55,8 +55,15 @@ Launch the **UCRT64 / MSYS2** profile for day-to-day development.
       mingw-w64-ucrt-x86_64-toolchain \
       mingw-w64-ucrt-x86_64-make \
       mingw-w64-ucrt-x86_64-pkgconf \
-      mingw-w64-ucrt-x86_64-cmake
+      mingw-w64-ucrt-x86_64-cmake \
+      mingw-w64-ucrt-x86_64-glslang \
+      mingw-w64-ucrt-x86_64-clang-tools-extra
   ```
+
+Notes:
+
+- `mingw-w64-ucrt-x86_64-glslang` provides the GLSL tools used to compile shaders during the build.
+- `mingw-w64-ucrt-x86_64-clang-tools-extra` provides `clang-format`, `clang-tidy`, and related tooling used by `./sj format` and `./sj lint`.
 
 ## Git + SSH
 
@@ -76,7 +83,7 @@ git config --global commit.gpgsign true
 
 ## Shell profile (`~/.zshrc`)
 
-Add environment variables and helpers so builds find the right tools and vcpkg triplets:
+Add environment variables and helpers so builds find the right tools and vcpkg:
 
 ```bash
 # Paths for VS Code (adjust if you use stable/insiders only)
@@ -85,8 +92,6 @@ export PATH="$PATH:/c/Users/$USERNAME/AppData/Local/Programs/Microsoft VS Code/b
 
 # vcpkg
 export VCPKG_ROOT=/c/tools/vcpkg
-export VCPKG_DEFAULT_TRIPLET=x64-mingw-dynamic
-export VCPKG_DEFAULT_HOST_TRIPLET=x64-mingw-dynamic
 
 # Shortcuts
 alias vi='vim'
@@ -101,4 +106,4 @@ if ! ssh_agent_is_running; then
 fi
 ```
 
-At this point the UCRT64 shell has the compilers, CMake, vcpkg defaults, and SSH credentials you need to work on Steeplejack.
+At this point the UCRT64 shell has the compilers, CMake, vcpkg, and SSH credentials you need to work on Steeplejack.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,20 +1,9 @@
-# Development Environments
+# Development Environment
 
-Steeplejack targets **Windows** using the MSYS2 **UCRT64 + GCC** toolchain.
+Steeplejack targets Windows using the MSYS2 UCRT64 + GCC toolchain.
 
-## MSYS2 UCRT64 (primary)
-
-- Produces the shipping Windows binaries (Vulkan requires Windows/Mingw runtime)
-- Uses GCC, Ninja, and the Vulkan SDK provided via MSYS2 packages + vcpkg
+- Uses GCC, Ninja, and Vulkan SDK headers/libraries via MSYS2 packages and vcpkg
 - Follow [MSYS2](./MSYS2.md) for setup (terminal profiles, packages, env vars)
-
-## WSL2
-
-WSL is not supported for this project.
-
-## Why both?
-
-All tooling should run via MSYS2.
 
 ## Bonus: no Visual Studio required
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -60,7 +60,7 @@ configure_and_build() {
 }
 
 env_name=$(steeplejack_detect_environment) || {
-    echo "Unable to detect environment (expected MSYS2 UCRT64 or WSL2)." >&2
+    echo "Unable to detect environment (expected MSYS2 UCRT64)." >&2
     exit 1
 }
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -31,7 +31,7 @@ clean_tree() {
 }
 
 env_name=$(steeplejack_detect_environment) || {
-    echo "Unable to detect environment (expected MSYS2 UCRT64 or WSL2)." >&2
+    echo "Unable to detect environment (expected MSYS2 UCRT64)." >&2
     exit 1
 }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -22,7 +22,7 @@ esac
 RUN_ARGS=("$@")
 
 env_name=$(steeplejack_detect_environment) || {
-    echo "Unable to detect environment (expected MSYS2 UCRT64 or WSL2)." >&2
+    echo "Unable to detect environment (expected MSYS2 UCRT64)." >&2
     exit 1
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,7 +13,7 @@ esac
 
 ROOT_DIR=$(steeplejack_root)
 env_name=$(steeplejack_detect_environment) || {
-    echo "Unable to detect environment (expected MSYS2 UCRT64 or WSL2)." >&2
+    echo "Unable to detect environment (expected MSYS2 UCRT64)." >&2
     exit 1
 }
 
@@ -29,4 +29,3 @@ cmake --build "${build_dir}" --target steeplejack_tests
 
 echo "==> Running tests"
 ctest --test-dir "${build_dir}" --output-on-failure
-

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -6,7 +6,7 @@ find_program(GLSL_VALIDATOR
 )
 
 if(NOT GLSL_VALIDATOR)
-    message(FATAL_ERROR "glslangValidator not found! Please install mingw-w64-x86_64-glslang or set VULKAN_SDK")
+    message(FATAL_ERROR "glslangValidator not found! Please install mingw-w64-ucrt-x86_64-glslang or set VULKAN_SDK")
 endif()
 
 file(GLOB_RECURSE GLSL_SOURCE_FILES


### PR DESCRIPTION
Remove references to WSL2 throughout the documentation and scripts, focusing exclusively on MSYS2 UCRT64 as the primary development environment. Update instructions and error messages to reflect this change.